### PR TITLE
Fix field name

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,6 +1,6 @@
 ---
 name: Bug report
-about: Create a report to help us improve.
+description: Create a report to help us improve.
 labels: ["bug"]
 title: "[BUG]: "
 assignees:

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,6 +1,6 @@
 ---
 name: Feature request
-about: Suggest an idea for this project.
+description: Suggest an idea for this project.
 labels: ["enhancement"]
 title: "[FEATURE]: "
 assignees:


### PR DESCRIPTION
- [x] Linting passes
- [x] Tests are added and passing
- [x] Documentation is updated

It seems like that despite other projects using the `about` field it is not an allowed property and `description` has to be used.