### PR TITLE
Add workflow to deploy to GH pages

### DIFF
--- a/.github/workflows/docs_deploy.yml
+++ b/.github/workflows/docs_deploy.yml
@@ -1,0 +1,36 @@
+---
+
+name: Deploy Docs to GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.12
+
+      - name: Install dependencies
+        run: |
+          pip install --upgrade pip
+          pip install -e .[docs]
+
+      - name: Build documentation
+        run: |
+          sphinx-build -b html docs docs/build/html
+
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: docs/build/html

--- a/README.md
+++ b/README.md
@@ -7,25 +7,29 @@
 <a href="https://img.shields.io/github/license/daniel-mizsak/python-package-template" target="_blank"><img src="https://img.shields.io/github/license/daniel-mizsak/python-package-template" alt="license"></a>
 </div>
 
-
 ## Overview
+
 A GitHub template with my python package configurations.
 
 ## GitHub repository settings
+
 The following settings are enabled in my repository settings:
 
 Code/About:
+
 - Releases
 
 <br>
 
 General/Features:
+
 - Issues
 - Preserve this repository
 
 <br>
 
 General/Pull Requests:
+
 - Allow merge commits
 - Allow squash merging
 - Allow rebase merging
@@ -36,6 +40,7 @@ General/Pull Requests:
 Branches/Branch protection rules:\
 `main`\
 Protect matching branches
+
 - Require pull request reviews before merging
 - Dismiss stale pull request approvals when new commits are pushed
 - Require status checks to pass before merging
@@ -46,15 +51,25 @@ Protect matching branches
 
 Environments:\
 `pypi`
+
 - Deployment protection rules:
 - Required reviewers:
     `daniel-mizsak`
 - Allow administrators to bypass configured protection rules
 
+<br>
+
+Pages/Build and deployment:
+
+- Source: Deploy from branch
+- Branch: `gh-pages` (root)
+
 ## Setup PyPi trusted publishing
+
 [PyPi publishing settings](https://pypi.org/manage/account/publishing/)
 
 Add a new pending publisher:
+
 - PyPi Project Name: `python-package-template-pypi` (has to match the project name in `pyproject.toml`)
 - Owner: `daniel-mizsak`
 - Repository name: `python-package-template`

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -5,7 +5,7 @@ For the full list of built-in configuration values, see the documentation:
 https://www.sphinx-doc.org/en/master/usage/configuration.html
 
 Built docs locally with:
-sphinx-build -b html docs/source/ docs/build/html
+sphinx-build -b html docs docs/build/html
 
 @author "Daniel Mizsak" <info@pythonvilag.hu>
 """


### PR DESCRIPTION
Add workflow to deploy documentation to Github pages.
Resolves #2 

Modified settings:
- Pages/Source: Deploy from a branch
- Pages/Branch: `gh-pages`

- [x] Linting passes
- [x] Tests are added and passing
- [x] Documentation is updated
