### PR TITLE
Feature/move gh pages action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,13 +13,3 @@ jobs:
     uses: daniel-mizsak/workflows/.github/workflows/tox.yml@main
     with:
       python-version: "3.12"
-
-  gh-pages:
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    needs: tox
-    permissions:
-      contents: write
-
-    uses: daniel-mizsak/workflows/.github/workflows/gh-pages.yml@main
-    with:
-      python-version: "3.12"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,3 +37,11 @@ jobs:
 
       - name: Publish the package.
         uses: pypa/gh-action-pypi-publish@release/v1
+
+  gh-pages:
+    permissions:
+      contents: write
+
+    uses: daniel-mizsak/workflows/.github/workflows/gh-pages.yml@main
+    with:
+      python-version: "3.12"

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 A GitHub template with my python package configurations.
 
 ## Package tools
-This template package relies on the synchronized cooperation of several advanced tools.\
+This template package relies on the synchronized cooperation of several exceptional tools.\
 These tools include:
 - [Pre-Commit](https://pre-commit.com/) - Git hooks running on commits
 - [Hatch](https://hatch.pypa.io/latest/) - Package building
@@ -65,7 +65,8 @@ It can be used to test different Python versions and different testing scenarios
 In this repository tox is set up to use python 3.12 and run pytest, ruff, mypy and documentation tests.
 
 ### Documentation
-The documentation is built with Sphinx and it is hosted both on ReadTheDocs and GitHub Pages.\ Both of these services are recommended and ReadTheDocs does require a bit more setup, but I generally prefer it.
+The documentation is built with Sphinx and it is hosted both on ReadTheDocs and GitHub Pages.\
+Both of these services are recommended, however ReadTheDocs requires a bit more setup, but I prefer it as it does not require an extra feature branch to be present.
 
 
 ## GitHub repository settings


### PR DESCRIPTION
- [x] Linting passes
- [x] Tests are added and passing
- [x] Documentation is updated

The Github Pages release actions was previously part of the CI workflow, but only ran when the pushed to the main branch.

Now it is moved to the release workflow, so that it only runs on new tags leaving more time for potential corrections in the documentation.